### PR TITLE
Upgradle + buildscript work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,39 +1,26 @@
-#Git
-/.git
+# General use .gitignore for Minecraft modding.
 
-#Forge
-/.gradle
-/bin
-/build
-/eclipse
-/logs
-/mods
-/out
-.project
-.settings
-*.txt
-.classpath
+# Directories
+/.gradle/
+/build/
+/eclipse/
+/run/
+/out/
+/asm/
+/bin/
+/.idea/
+/.metadata/
+/.settings/
 
-#IntelliJ
-/.idea
-1.7.10.iml
-1.7.10.ipr
-1.7.10.iws
-ANSSRPG.iml
+# File Extensions
+*.psd
+*.iml
+*.ipr
+*.iws
+*.classpath
+*.project
+*.class
 
-#ANSSRPG
-/data
-/saves
-/world
-/crash-reports
-/config
-/resourcepacks
-banned-ips.json
-banned-players.json
-ops.json
-server.properties
-servers.dat
-usercache.json
-usernamecache.json
-whitelist.json
-output/
+# Specific files
+Thumbs.db
+.DS_store

--- a/build.gradle
+++ b/build.gradle
@@ -12,59 +12,87 @@ buildscript {
     }
     dependencies {
         classpath 'net.minecraftforge.gradle:ForgeGradle:1.2-SNAPSHOT'
+        classpath 'org.ajoberstar:gradle-git:0.10.1'
     }
 }
 
 apply plugin: 'forge'
 
-version = "DEV11"
-group= "com.disconsented.anssrpg" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
-archivesBaseName = "anssrpg"
+group = package_group
+archivesBaseName = mod_name
+version = "${mc_version}-${mod_version}"
 
 minecraft {
-    version = "1.7.10-10.13.2.1230"
-    assetDir = "eclipse/assets"
+    version = "${mc_version}-${forge_version}"
+    runDir = "run"
+}
+
+import org.ajoberstar.grgit.Grgit
+
+def gitHash = 'unknown'
+if (new File(projectDir, '.git').exists()) {
+    def repo = Grgit.open(project.file('.'))
+    gitHash = repo.log().find().abbreviatedId
+}
+
+repositories {
+
 }
 
 dependencies {
-    // you may put jars on which you depend on in ./libs
-    // or you may define them like so..
-    //compile "some.group:artifact:version:classifier"
-    //compile "some.group:artifact:version"
-      
-    // real examples
-    //compile 'com.mod-buildcraft:buildcraft:6.0.8:dev'  // adds buildcraft to the dev env
-    //compile 'com.googlecode.efficient-java-matrix-library:ejml:0.24' // adds ejml to the dev env
-
-    // for more info...
-    // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
-    // http://www.gradle.org/docs/current/userguide/dependency_management.html
 
 }
 
-processResources
-{
-    // this will ensure that this task is redone when the versions change.
+processResources {
     inputs.property "version", project.version
     inputs.property "mcversion", project.minecraft.version
 
-    // replace stuff in mcmod.info, nothing else
     from(sourceSets.main.resources.srcDirs) {
-        include 'mcmod.info'
-                
-        // replace version and mcversion
-        expand 'version':project.version, 'mcversion':project.minecraft.version
+        include '**/*.info'
+        include '**/*.properties'
+
+        expand 'version': project.version, 'mcversion': project.minecraft.version
     }
-        
-    // copy everything else, thats not the mcmod.info
     from(sourceSets.main.resources.srcDirs) {
-        exclude 'mcmod.info'
+        exclude '**/*.info'
+        exclude '**/*.properties'
     }
 }
+
 targetCompatibility=7
 sourceCompatibility=7
-task deobfJar(type: Jar){
+
+jar {
+    classifier = ''
+    manifest.mainAttributes(
+            "Built-By": System.getProperty('user.name'),
+            "Created-By": "${System.getProperty('java.vm.version')} + (${System.getProperty('java.vm.vendor')})",
+            "Implementation-Title": project.name,
+            "Implementation-Version": project.version,
+            "Git-Hash": gitHash
+    )
+}
+
+// Source Jar
+task sourceJar(type: Jar) {
+    from sourceSets.main.allSource
+    classifier = 'sources'
+}
+
+// Javadoc Jar
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    from javadoc.destinationDir
+    classifier = 'javadoc'
+}
+
+// Deobfuscated Jar
+task deobfJar(type: Jar) {
     from sourceSets.main.output
-    from sourceSets.api.output
-    classifier = 'dev'
+    classifier = 'deobf'
+}
+
+tasks.build.dependsOn sourceJar, javadocJar, deobfJar
+
+tasks.withType(JavaCompile) { task ->
+    task.options.encoding = 'UTF-8'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,7 @@
+mod_name=ANSSRPG
+package_group=com.disconsented.anssrpg
+
+mc_version=1.7.10
+forge_version=10.13.2.1230
+
+mod_version=DEV11

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-bin.zip


### PR DESCRIPTION
Hopefully this doesn't conflict with any un-committed changes you have.

* Updated Gradle:  `1.12 -> 2.2.1`
* Cleaned up `build.gradle`
 * Added creation of `sources` and `javadoc` jars.
 * Moved constants to `gradle.properties` file.
 * Added a `MANIFEST.MF` file to the jar. It includes basic information:
    - Name of builder
    - Java version/vender
    - Project name
    - Project version
    - Git hash it was built from
 * Changed from the deprecated `assetDir` to `runDir` and set `runDir` to
`../run/` instead of `../eclipse/`.
* Edited `.gitignore` to include the new `../run/` directory as well as
*all* Idea files. Basically I just copied over the one that I use in all
of my other projects.