### PR TITLE
Fix: squid:S2293, The operator ("<>") should be used.

### DIFF
--- a/src/main/java/disconsented/anssrpg/client/Data.java
+++ b/src/main/java/disconsented/anssrpg/client/Data.java
@@ -33,9 +33,9 @@ import disconsented.anssrpg.network.SkillInfo;
  *
  */
 public class Data {
-	public static HashMap<String, SkillInfo> skillInfo = new HashMap<String, SkillInfo>();
-	public static ArrayList<SkillInfo> skillInfoList = new ArrayList<SkillInfo>();
-	public static LinkedHashMap<String, PerkInfo> perkInfo = new LinkedHashMap<String, PerkInfo>(); //Ensures that perks are all unique, allows for easy overridng
+	public static HashMap<String, SkillInfo> skillInfo = new HashMap<>();
+	public static ArrayList<SkillInfo> skillInfoList = new ArrayList<>();
+	public static LinkedHashMap<String, PerkInfo> perkInfo = new LinkedHashMap<>(); //Ensures that perks are all unique, allows for easy overridng
 	public static String statusMessage = "";
 	
 

--- a/src/main/java/disconsented/anssrpg/config/Default.java
+++ b/src/main/java/disconsented/anssrpg/config/Default.java
@@ -51,7 +51,7 @@ public class Default {
                     "Allows you to mine Iron Ore",
                     0,
                     new ArrayList<BNP>() {{
-                        this.add(new BNP("iron_ore", new HashMap<String, String>()));
+                        this.add(new BNP("iron_ore", new HashMap<>()));
                     }}));
 
             Default.perks.addPerk(new BlockPerk("Unlock: Lapis Ore",
@@ -61,7 +61,7 @@ public class Default {
                     "Allows you to mine Lapis Ore",
                     0,
                     new ArrayList<BNP>() {{
-                        this.add(new BNP("lapis_ore", new HashMap<String, String>()));
+                        this.add(new BNP("lapis_ore", new HashMap<>()));
                     }}));
 
             Default.perks.addPerk(new BlockPerk("Unlock: Gold Ore",
@@ -71,7 +71,7 @@ public class Default {
                     "Allows you to mine Gold Ore",
                     0,
                     new ArrayList<BNP>() {{
-                        this.add(new BNP("gold_ore", new HashMap<String, String>()));
+                        this.add(new BNP("gold_ore", new HashMap<>()));
                     }}));
 
             Default.perks.addPerk(new BlockPerk("Unlock: Redstone Ore",
@@ -81,7 +81,7 @@ public class Default {
                     "Allows you to mine Redstone Ore",
                     0,
                     new ArrayList<BNP>() {{
-                        this.add(new BNP("lit_redstone_ore", new HashMap<String, String>()));
+                        this.add(new BNP("lit_redstone_ore", new HashMap<>()));
                     }}));
 
             Default.perks.addPerk(new BlockPerk("Unlock: Diamond Ore",
@@ -91,7 +91,7 @@ public class Default {
                     "Allows you to mine Diamond Ore",
                     0,
                     new ArrayList<BNP>() {{
-                        this.add(new BNP("diamond_ore", new HashMap<String, String>()));
+                        this.add(new BNP("diamond_ore", new HashMap<>()));
                     }}));
 
             Default.perks.addPerk(new BlockPerk("Unlock: Emerald Ore",
@@ -101,7 +101,7 @@ public class Default {
                     "Allows you to mine Emerald Ore",
                     0,
                     new ArrayList<BNP>() {{
-                        this.add(new BNP("emerald_ore", new HashMap<String, String>()));
+                        this.add(new BNP("emerald_ore", new HashMap<>()));
                     }}));
 
             Default.perks.addPerk(new ItemPerk("Unlock: Gold Armour",

--- a/src/main/java/disconsented/anssrpg/config/SkillContainer.java
+++ b/src/main/java/disconsented/anssrpg/config/SkillContainer.java
@@ -39,11 +39,11 @@ import disconsented.anssrpg.skill.objects.Skill;
 public class SkillContainer {
 
     @Expose
-    private ArrayList<BlockSkill> blocks = new ArrayList<BlockSkill>();
+    private ArrayList<BlockSkill> blocks = new ArrayList<>();
     @Expose
-    private final ArrayList<EntitySkill> entites = new ArrayList<EntitySkill>();
+    private final ArrayList<EntitySkill> entites = new ArrayList<>();
     @Expose
-    private final ArrayList<ItemSkill> items = new ArrayList<ItemSkill>();
+    private final ArrayList<ItemSkill> items = new ArrayList<>();
 
 
     public void addBlockSkill(BlockSkill blockSkill) {
@@ -69,7 +69,7 @@ public class SkillContainer {
     }
 
     public void touchUp() {
-        ArrayList<Skill> skills = new ArrayList<Skill>();
+        ArrayList<Skill> skills = new ArrayList<>();
         skills.addAll(this.blocks);
         skills.addAll(this.entites);
         skills.addAll(this.items);

--- a/src/main/java/disconsented/anssrpg/data/ContainerRegistry.java
+++ b/src/main/java/disconsented/anssrpg/data/ContainerRegistry.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
  *
  */
 public class ContainerRegistry {
-    public HashMap<String,Class> container = new HashMap<String,Class>();
+    public HashMap<String,Class> container = new HashMap<>();
     public static void init(){
         
     }

--- a/src/main/java/disconsented/anssrpg/data/PerkStore.java
+++ b/src/main/java/disconsented/anssrpg/data/PerkStore.java
@@ -37,15 +37,15 @@ import java.util.HashMap;
  * Just stores and retrieves perks
  */
 public class PerkStore {
-    private static final ArrayList<Perk> perks = new ArrayList<Perk>();
+    private static final ArrayList<Perk> perks = new ArrayList<>();
     /*String needs to be a name unique to each entity type*/
-    private static final HashMap<String, ArrayList<BlockPerk>> blockMap = new HashMap<String, ArrayList<BlockPerk>>();
-    private static final HashMap<String, ArrayList<EntityPerk>> entityMap = new HashMap<String, ArrayList<EntityPerk>>();
-    private static final HashMap<String, ArrayList<ItemPerk>> itemMap = new HashMap<String, ArrayList<ItemPerk>>();
-    private static final ArrayList<TitlePerk> titlePerks = new ArrayList<TitlePerk>();
-    private static final ArrayList<PotionSelfPerk> potionSelf = new ArrayList<PotionSelfPerk>();
+    private static final HashMap<String, ArrayList<BlockPerk>> blockMap = new HashMap<>();
+    private static final HashMap<String, ArrayList<EntityPerk>> entityMap = new HashMap<>();
+    private static final HashMap<String, ArrayList<ItemPerk>> itemMap = new HashMap<>();
+    private static final ArrayList<TitlePerk> titlePerks = new ArrayList<>();
+    private static final ArrayList<PotionSelfPerk> potionSelf = new ArrayList<>();
     
-    private static final HashMap<String, Perk> perksMap = new HashMap<String, Perk>();
+    private static final HashMap<String, Perk> perksMap = new HashMap<>();
     private static PerkStore instance;
 
     private PerkStore() {}
@@ -117,7 +117,7 @@ public class PerkStore {
         if (cachePerkList != null){
             cachePerkList.add(perk);
         } else {
-            ArrayList<t> newPerkList = new ArrayList<t>();
+            ArrayList<t> newPerkList = new ArrayList<>();
             newPerkList.add(perk);
             abstractMap.put(name, newPerkList);
         }

--- a/src/main/java/disconsented/anssrpg/data/PlayerStore.java
+++ b/src/main/java/disconsented/anssrpg/data/PlayerStore.java
@@ -36,7 +36,7 @@ import net.minecraft.entity.player.EntityPlayerMP;
  *         Stores player's into a hashmap with the Key being their UUID
  */
 public class PlayerStore {
-    private static final HashMap<String, PlayerData> data = new HashMap<String, PlayerData>();
+    private static final HashMap<String, PlayerData> data = new HashMap<>();
 
     private static PlayerStore instance;
 

--- a/src/main/java/disconsented/anssrpg/data/SkillStore.java
+++ b/src/main/java/disconsented/anssrpg/data/SkillStore.java
@@ -39,10 +39,10 @@ import java.util.ArrayList;
  */
 public class SkillStore {
     private static SkillStore instance;
-    private static ArrayList<BlockSkill> blockSkill = new ArrayList<BlockSkill>();
-    private static ArrayList<EntitySkill> entitySkill = new ArrayList<EntitySkill>();
-    private static ArrayList<ItemSkill> itemSkill = new ArrayList<ItemSkill>();
-    private static ArrayList<Skill> skills = new ArrayList<Skill>();
+    private static ArrayList<BlockSkill> blockSkill = new ArrayList<>();
+    private static ArrayList<EntitySkill> entitySkill = new ArrayList<>();
+    private static ArrayList<ItemSkill> itemSkill = new ArrayList<>();
+    private static ArrayList<Skill> skills = new ArrayList<>();
 
     protected SkillStore() {/* Exists only to defeat instantiation.*/}
 
@@ -63,10 +63,10 @@ public class SkillStore {
     }
 
     public static void Clear() {
-        SkillStore.blockSkill = new ArrayList<BlockSkill>();
-        SkillStore.entitySkill = new ArrayList<EntitySkill>();
-        SkillStore.itemSkill = new ArrayList<ItemSkill>();
-        SkillStore.skills = new ArrayList<Skill>();
+        SkillStore.blockSkill = new ArrayList<>();
+        SkillStore.entitySkill = new ArrayList<>();
+        SkillStore.itemSkill = new ArrayList<>();
+        SkillStore.skills = new ArrayList<>();
     }
 
     public static ArrayList<BlockSkill> getBlockSkill() {

--- a/src/main/java/disconsented/anssrpg/data/ToolRegistry.java
+++ b/src/main/java/disconsented/anssrpg/data/ToolRegistry.java
@@ -40,7 +40,7 @@ import net.minecraft.item.ItemSword;
  */
 public final class ToolRegistry {
     
-    private static final HashMap<String, Class> registry = new HashMap<String, Class>();
+    private static final HashMap<String, Class> registry = new HashMap<>();
     
     public static void init(){
         ToolRegistry.registry.put("Pickaxe", ItemPickaxe.class);

--- a/src/main/java/disconsented/anssrpg/gui/GUIExperience.java
+++ b/src/main/java/disconsented/anssrpg/gui/GUIExperience.java
@@ -45,7 +45,7 @@ import net.minecraft.util.ResourceLocation;
  *
  */
 public class GUIExperience extends GuiScreen {    
-    private final ArrayList<ExpBox> boxes = new ArrayList<ExpBox>();
+    private final ArrayList<ExpBox> boxes = new ArrayList<>();
     private int page;
     private int boxCount;
     

--- a/src/main/java/disconsented/anssrpg/gui/GUIPerk.java
+++ b/src/main/java/disconsented/anssrpg/gui/GUIPerk.java
@@ -48,7 +48,7 @@ public class GUIPerk extends GuiScreen {
     private PerkControls perkControls;
     private int page;
     private PerkInfo selected;
-    private final ArrayList<PerkInfo> info = new ArrayList<PerkInfo>();
+    private final ArrayList<PerkInfo> info = new ArrayList<>();
     private List<PerkInfo> subList = new ArrayList<>();
 
 

--- a/src/main/java/disconsented/anssrpg/network/ActivePerks.java
+++ b/src/main/java/disconsented/anssrpg/network/ActivePerks.java
@@ -46,7 +46,7 @@ public class ActivePerks implements IMessage {
     @Override
     public void fromBytes(ByteBuf buf) {
         int i = buf.readInt();
-        this.activePerks = new ArrayList<String>();
+        this.activePerks = new ArrayList<>();
         for (int j = 0; j < i; j++) {
             this.activePerks.add(ByteBufUtils.readUTF8String(buf));
         }

--- a/src/main/java/disconsented/anssrpg/network/PerkInfo.java
+++ b/src/main/java/disconsented/anssrpg/network/PerkInfo.java
@@ -35,9 +35,9 @@ public class PerkInfo implements IMessage {
     private String description;
     private int pointCost;
     private ArrayList<Requirement> requirements;
-    private final ArrayList<String> names = new ArrayList<String>();
-    private final ArrayList<String> extraData = new ArrayList<String>();
-    private final ArrayList<Action> actions = new ArrayList<Action>();
+    private final ArrayList<String> names = new ArrayList<>();
+    private final ArrayList<String> extraData = new ArrayList<>();
+    private final ArrayList<Action> actions = new ArrayList<>();
     private int size;
     private String slug;
     private boolean obtained;
@@ -66,7 +66,7 @@ public class PerkInfo implements IMessage {
         this.description = ByteBufUtils.readUTF8String(buf);
         this.slug = ByteBufUtils.readUTF8String(buf);
         this.pointCost = buf.readInt();
-        this.requirements = new ArrayList<Requirement>();
+        this.requirements = new ArrayList<>();
         for (int i = 0; i < this.size; i++) {
             this.requirements.add(new Requirement(Action.valueOf(ByteBufUtils.readUTF8String(buf)), ByteBufUtils.readUTF8String(buf), ByteBufUtils.readUTF8String(buf)));
         }
@@ -101,7 +101,7 @@ public class PerkInfo implements IMessage {
     }
 
     public ArrayList<Requirement> getRequirements() {
-        ArrayList<Requirement> req = new ArrayList<Requirement>();
+        ArrayList<Requirement> req = new ArrayList<>();
         for (int i = 0; i < this.names.size(); i++) {
             req.add(new Requirement(this.actions.get(i), this.names.get(i), this.extraData.get(i)));
         }

--- a/src/main/java/disconsented/anssrpg/perk/BlockPerk.java
+++ b/src/main/java/disconsented/anssrpg/perk/BlockPerk.java
@@ -35,7 +35,7 @@ import disconsented.anssrpg.common.Logging;
 public class BlockPerk extends Perk {
 
     @Expose
-    public ArrayList<BNP> blocks = new ArrayList<BNP>();
+    public ArrayList<BNP> blocks = new ArrayList<>();
 
     public BlockPerk() {
     }
@@ -48,7 +48,7 @@ public class BlockPerk extends Perk {
 
     @Override
     public void searchObject() {
-        ArrayList<BNP> initialised = new ArrayList<BNP>();
+        ArrayList<BNP> initialised = new ArrayList<>();
         for(BNP object : this.blocks){
             object.block = (Block)Block.blockRegistry.getObject(object.name);
             if (object.block != null){

--- a/src/main/java/disconsented/anssrpg/perk/EntityPerk.java
+++ b/src/main/java/disconsented/anssrpg/perk/EntityPerk.java
@@ -38,7 +38,7 @@ public class EntityPerk extends Perk {
     public EntityPerk(){}
 
     @Expose
-    public ArrayList<ENE> entities = new ArrayList<ENE>();
+    public ArrayList<ENE> entities = new ArrayList<>();
 
     public EntityPerk(String name, ArrayList<Requirement> requirements,
                       String description, int pointCost, ArrayList<ENE> entities) {
@@ -48,7 +48,7 @@ public class EntityPerk extends Perk {
 
     @Override
     public void searchObject() {
-        ArrayList<ENE> initialised = new ArrayList<ENE>();
+        ArrayList<ENE> initialised = new ArrayList<>();
         for(ENE object : this.entities){
             object.entity = (Class) EntityList.stringToClassMapping.get(object.name);
             if (object.entity != null){

--- a/src/main/java/disconsented/anssrpg/perk/ItemPerk.java
+++ b/src/main/java/disconsented/anssrpg/perk/ItemPerk.java
@@ -38,7 +38,7 @@ import disconsented.anssrpg.objects.INME;
 public class ItemPerk extends Perk {
 
     @Expose
-    public ArrayList<INM> items = new ArrayList<INM>();
+    public ArrayList<INM> items = new ArrayList<>();
 
     public ItemPerk() {
     }

--- a/src/main/java/disconsented/anssrpg/perk/Perk.java
+++ b/src/main/java/disconsented/anssrpg/perk/Perk.java
@@ -33,7 +33,7 @@ public abstract class Perk {
     @Expose
     public String name = "default_name";
     @Expose
-    public ArrayList<Requirement> requirements = new ArrayList<Requirement>();
+    public ArrayList<Requirement> requirements = new ArrayList<>();
     public Slug slug;//Not exposed as its made based on the name
     @Expose
     public String description = "default_description";
@@ -103,7 +103,7 @@ public abstract class Perk {
         this.searchObject();
         this.getSlug();
         if (requirements == null) {
-            requirements = new ArrayList<Requirement>();
+            requirements = new ArrayList<>();
         }
     }
 

--- a/src/main/java/disconsented/anssrpg/perk/PotionSelfPerk.java
+++ b/src/main/java/disconsented/anssrpg/perk/PotionSelfPerk.java
@@ -54,7 +54,7 @@ public class PotionSelfPerk extends Perk implements ActivePerk{
     public PotionSelfPerk(){}
     
     @Expose
-    public ArrayList<PotionDefinition> effects = new ArrayList<PotionDefinition>();    
+    public ArrayList<PotionDefinition> effects = new ArrayList<>();
     @Expose
     public boolean repeat;
     @Expose

--- a/src/main/java/disconsented/anssrpg/player/PlayerData.java
+++ b/src/main/java/disconsented/anssrpg/player/PlayerData.java
@@ -34,9 +34,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 public class PlayerData {
-    private ArrayList<Slug> perkList = new ArrayList<Slug>();
-    private ArrayList<Slug> activePerks = new ArrayList<Slug>();
-    private HashMap<String, Integer> skillExp = new HashMap<String, Integer>();
+    private ArrayList<Slug> perkList = new ArrayList<>();
+    private ArrayList<Slug> activePerks = new ArrayList<>();
+    private HashMap<String, Integer> skillExp = new HashMap<>();
     private String playerID;
     private int points;
 

--- a/src/main/java/disconsented/anssrpg/skill/objects/BlockSkill.java
+++ b/src/main/java/disconsented/anssrpg/skill/objects/BlockSkill.java
@@ -40,13 +40,13 @@ import disconsented.anssrpg.objects.BNEP;
 public class BlockSkill extends ToolSkill {
     
     @Expose
-    public ArrayList<BNEP> exp = new ArrayList<BNEP>();
+    public ArrayList<BNEP> exp = new ArrayList<>();
     
     @Override
     public void touchUp() {
         this.initTool();
         
-        ArrayList<BNEP> initialised = new ArrayList<BNEP>();
+        ArrayList<BNEP> initialised = new ArrayList<>();
         for (BNEP object : this.exp) {
             object.block = (Block) Block.blockRegistry.getObject(object.name);
             if (object.block != null){

--- a/src/main/java/disconsented/anssrpg/skill/objects/EntitySkill.java
+++ b/src/main/java/disconsented/anssrpg/skill/objects/EntitySkill.java
@@ -37,13 +37,13 @@ import disconsented.anssrpg.objects.ENE;
 public class EntitySkill extends ToolSkill {
     
     @Expose
-    public ArrayList<ENE> exp = new ArrayList<ENE>();
+    public ArrayList<ENE> exp = new ArrayList<>();
 
     @Override
     public void touchUp() {
         this.initTool();
         
-        ArrayList<ENE> initialised = new ArrayList<ENE>();
+        ArrayList<ENE> initialised = new ArrayList<>();
         for (ENE object : this.exp) {
             object.entity = (Class) EntityList.stringToClassMapping.get(object.name);
             if (object.entity != null){

--- a/src/main/java/disconsented/anssrpg/task/TaskMaster.java
+++ b/src/main/java/disconsented/anssrpg/task/TaskMaster.java
@@ -35,8 +35,8 @@ public class TaskMaster{
 	protected TaskMaster(){}
 	
 	private static TaskMaster master;
-	private final Queue<Task> queue = new LinkedList<Task>();
-	private final Queue<Task> currentQueue = new LinkedList<Task>();
+	private final Queue<Task> queue = new LinkedList<>();
+	private final Queue<Task> currentQueue = new LinkedList<>();
 	
 	public static TaskMaster getInstance(){
 		if (TaskMaster.master == null){


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2293 - “The diamond operator (""<>"") should be used ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2293
 Please let me know if you have any questions.
Ayman Elkfrawy.