### PR TITLE
Fix: squid:S1118, Utility classes should not have public constructors

### DIFF
--- a/src/main/java/disconsented/anssrpg/client/Data.java
+++ b/src/main/java/disconsented/anssrpg/client/Data.java
@@ -37,6 +37,8 @@ public class Data {
 	public static ArrayList<SkillInfo> skillInfoList = new ArrayList<SkillInfo>();
 	public static LinkedHashMap<String, PerkInfo> perkInfo = new LinkedHashMap<String, PerkInfo>(); //Ensures that perks are all unique, allows for easy overridng
 	public static String statusMessage = "";
-	
 
+
+	private Data() {
+	}
 }

--- a/src/main/java/disconsented/anssrpg/common/Logging.java
+++ b/src/main/java/disconsented/anssrpg/common/Logging.java
@@ -29,6 +29,9 @@ import org.apache.logging.log4j.Logger;
 public class Logging {
     private static final Logger logger = LogManager.getLogger("ANSSRPG");
 
+    private Logging() {
+    }
+
     public static void info(Object info) {
         if (Settings.getLogging())
             Logging.logger.info(info);

--- a/src/main/java/disconsented/anssrpg/common/Reference.java
+++ b/src/main/java/disconsented/anssrpg/common/Reference.java
@@ -32,4 +32,7 @@ public class Reference {
     public static final String VERSION = "@VERSION@";
     public static final String CLIENTPROXY = "disconsented.anssrpg.client.ClientProxy";
     public static final String COMMONPROXY = "disconsented.anssrpg.CommonProxy";
+
+    private Reference() {
+    }
 }

--- a/src/main/java/disconsented/anssrpg/common/Utils.java
+++ b/src/main/java/disconsented/anssrpg/common/Utils.java
@@ -31,6 +31,9 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public class Utils {
+    private Utils() {
+    }
+
     /**
      * Returns true if two objects are matched. If either Metadata is <= -1 then it is treated as a wildcard (Metadata is ignored)
      * @param object1
@@ -95,6 +98,9 @@ public class Utils {
      *
      */
     public static class Tools {
+        private Tools() {
+        }
+
         public static String stringToSlug(String value){
             return value.toLowerCase().replaceAll("[^A-Za-z0-9]", "");
         }

--- a/src/main/java/disconsented/anssrpg/config/JsonConfigHandler.java
+++ b/src/main/java/disconsented/anssrpg/config/JsonConfigHandler.java
@@ -50,6 +50,9 @@ public class JsonConfigHandler {
     private static final File perkFile = new File("config/ANSSRPG", "perk.cfg");
     private static final File configFileLocation = new File("config/ANSSRPG");
 
+    private JsonConfigHandler() {
+    }
+
     public static void createPerkAndSkill() {
         JsonConfigHandler.createSkillConfig(null);
         JsonConfigHandler.createPerkConfig(null);

--- a/src/main/java/disconsented/anssrpg/data/ToolRegistry.java
+++ b/src/main/java/disconsented/anssrpg/data/ToolRegistry.java
@@ -41,7 +41,10 @@ import net.minecraft.item.ItemSword;
 public final class ToolRegistry {
     
     private static final HashMap<String, Class> registry = new HashMap<String, Class>();
-    
+
+    private ToolRegistry() {
+    }
+
     public static void init(){
         ToolRegistry.registry.put("Pickaxe", ItemPickaxe.class);
         ToolRegistry.registry.put("Spade", ItemSpade.class);

--- a/src/main/java/disconsented/anssrpg/handler/SkillHandler.java
+++ b/src/main/java/disconsented/anssrpg/handler/SkillHandler.java
@@ -35,7 +35,10 @@ import net.minecraft.item.Item;
  * @author Disconsented
  */
 public class SkillHandler {
-    
+
+    private SkillHandler() {
+    }
+
     public static double calculateExpForLevel(Skill skill, double level){
         return SkillHandler.calculateExpForLevel(skill.base, level, skill.mod);
     }

--- a/src/main/java/disconsented/anssrpg/helper/Color.java
+++ b/src/main/java/disconsented/anssrpg/helper/Color.java
@@ -31,4 +31,6 @@ public class Color {
     public static int greyDeep = 0xFF373737;
     public static int brownPaper = 0xFFCAAF7A;
 
+    private Color() {
+    }
 }

--- a/src/main/java/disconsented/anssrpg/network/Manager.java
+++ b/src/main/java/disconsented/anssrpg/network/Manager.java
@@ -29,7 +29,10 @@ import disconsented.anssrpg.Main;
 import disconsented.anssrpg.common.Reference;
 
 public class Manager {
-	
+
+	private Manager() {
+	}
+
 	public static void init(){
 
 		Main.snw = NetworkRegistry.INSTANCE.newSimpleChannel(Reference.ID);

--- a/src/main/java/disconsented/anssrpg/player/PlayerFile.java
+++ b/src/main/java/disconsented/anssrpg/player/PlayerFile.java
@@ -35,6 +35,9 @@ import java.io.*;
 public class PlayerFile {
 
 
+    private PlayerFile() {
+    }
+
     public static void loadPlayer(String playerID) {
         File dataLocation = new File(Settings.getFolder(), playerID+".json");
         if (dataLocation.exists()){


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118

 Please let me know if you have any questions.
Ayman Elkfrawy.